### PR TITLE
Fixing Travis CI error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,9 @@ r:
   - release
   - devel
 
-r_github_packages:
-  - jimhester/lintr
+r_packages:
+  - lintr
+  - covr
 
 after_success:
   - Rscript -e 'covr::codecov()'

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,8 +12,7 @@ License: MIT + file LICENSE
 Encoding: UTF-8
 ByteCompile: true
 RoxygenNote: 7.1.1
-Suggests: covr,
-    testthat,
+Suggests: testthat,
     knitr,
     rmarkdown
 VignetteBuilder: knitr


### PR DESCRIPTION
Travis CI started throwing an error on monthly check. Something is up with trying to install lintr from github. I've moved covr and lintr from suggests to the Travis CI yml file because they have nothing to do with the package build, only the checks run there.